### PR TITLE
Implement WORLD-based processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Rust-WORLD"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aff6f1938ca10d10bf36fb2e2cc9f169b23ab44274cd301b9615bfa72881fc3"
+dependencies = [
+ "rsworld",
+ "rsworld-sys",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +244,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +313,12 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "lock_api"
@@ -399,6 +441,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,7 +510,11 @@ dependencies = [
 name = "phantom_silhouette_rs"
 version = "0.1.0"
 dependencies = [
+ "Rust-WORLD",
+ "hound",
  "nih_plug",
+ "rand",
+ "rand_distr",
 ]
 
 [[package]]
@@ -472,6 +528,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -489,6 +554,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -513,6 +618,24 @@ source = "git+https://github.com/nicokoch/reflink.git?rev=e8d93b465f5d9ad340cd05
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "rsworld"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9a17d9968e83337c1528b1589e1ee9f4373729cbd4aa6e464649bc55a1a0ec"
+dependencies = [
+ "rsworld-sys",
+]
+
+[[package]]
+name = "rsworld-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f3d097f63fd46fbf37066a56d14ff44d6bafe8a9decd6f6cab2d7e4409ada0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -602,6 +725,12 @@ checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
@@ -769,6 +898,12 @@ source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix%2Fdrop-box-
 dependencies = [
  "vst3-com",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "widestring"
@@ -960,4 +1095,24 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "nih_plug_xtask",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,17 @@ description = "phantom silhouette effect"
 members = ["xtask"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Remove the `assert_process_allocs` feature to allow allocations on the audio
 # thread in debug builds.
 nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", features = ["assert_process_allocs"] }
+# WORLD vocoder bindings
+Rust-WORLD = "0.1.1"
+hound = "3.5"
+rand = { version = "0.8", features = ["small_rng"] }
+rand_distr = "0.4"
 # Uncomment the below line to disable the on-by-default VST3 feature to remove
 # the GPL compatibility requirement
 # nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", default-features = false, features = ["assert_process_allocs"] }

--- a/README.md
+++ b/README.md
@@ -7,3 +7,49 @@ After installing [Rust](https://rustup.rs/), you can compile Phantom Silhouette 
 ```shell
 cargo xtask bundle phantom_silhouette_rs --release
 ```
+
+## WORLD comparison test
+
+A small test verifies that the WORLD vocoder bindings in Rust produce the same fundamental frequency values as `pyworld`. After installing the `numpy` and `pyworld` Python packages, run:
+
+```shell
+cargo test --test world_integration -- --nocapture
+```
+
+This invokes `script/extract_f0.py` on `test_sample/a01.wav` and compares its output with the Rust implementation.
+Only voiced frames (where the extracted F0 is non‑zero) are taken into account for the comparison.
+
+## Phantom Silhouette script
+
+A small Python script in `script/phantom_silhouette.py` applies the Phantom Silhouette voice conversion. It replaces the excitation signal with white or pink noise and adjusts the spectral envelope without formant shifting.
+
+Run it as follows to process a wav file:
+
+```shell
+python3 script/phantom_silhouette.py input.wav output.wav [pink]
+```
+
+Add `pink` to use pink noise instead of white noise.
+
+## Plugin parameters
+
+The VST plugin exposes one control:
+
+- **Mix** – Cross‑fades between the incoming audio and the processed
+  Phantom Silhouette signal. `1.0` leaves the original untouched, while
+  `0.0` outputs only the converted whisper.
+
+The plugin now performs the full WORLD‑based Phantom Silhouette conversion
+internally. Each buffer is analyzed with WORLD, the excitation is replaced with
+pink noise, and the modified spectral envelope is resynthesized before being
+blended with the input signal.
+
+## VST runtime test
+
+`script/test_vst.py` loads the compiled plugin with pedalboard and runs it on
+`test_sample/a01.wav` for a few sample rates and channel counts.  It prints the
+elapsed processing time for each run.  Run it after bundling the plugin:
+
+```shell
+python3 script/test_vst.py
+```

--- a/script/extract_f0.py
+++ b/script/extract_f0.py
@@ -1,0 +1,23 @@
+import wave
+import sys
+import numpy as np
+import pyworld as pw
+
+path = sys.argv[1]
+with wave.open(path, 'rb') as wf:
+    fs = wf.getframerate()
+    n = wf.getnframes()
+    samples = wf.readframes(n)
+    dtype = {1: np.int8, 2: np.int16, 4: np.int32}[wf.getsampwidth()]
+    x = np.frombuffer(samples, dtype=dtype).astype(np.float64)
+    if wf.getnchannels() > 1:
+        x = x.reshape(-1, wf.getnchannels())[:,0]
+    if wf.getsampwidth() == 2:
+        x /= 32768.0
+    elif wf.getsampwidth() == 1:
+        x = (x - 128) / 128.0
+    elif wf.getsampwidth() == 4:
+        x /= 2147483648.0
+_f0, t = pw.dio(x, fs)
+f0 = pw.stonemask(x, _f0, t, fs)
+print(" ".join(f"{v:.6f}" for v in f0))

--- a/script/phantom_silhouette.py
+++ b/script/phantom_silhouette.py
@@ -1,0 +1,170 @@
+from typing import Tuple
+import sys
+import wave
+
+import numpy as np
+import pyworld as pw
+
+
+def hz_to_spec(hz: np.ndarray, sr: int, spec_samples: int) -> np.ndarray:
+    """Convert physical frequency to spectrogram coordinate."""
+    return (hz / (sr // 2)) * spec_samples
+
+
+def hz_to_erb(hz: np.ndarray) -> np.ndarray:
+    """Convert Hertz to the ERB scale."""
+    return 21.4 * np.log(0.00437 * hz + 1) / np.log(10)
+
+
+def erb_to_hz(erb: np.ndarray) -> np.ndarray:
+    """Convert ERB values back to Hertz."""
+    return (np.exp(erb / 21.4 * np.log(10)) - 1) / 0.00437
+
+
+def low_frequency_suppression(sp: np.ndarray, sr: int) -> np.ndarray:
+    """Suppress low frequency components."""
+    freqs = np.arange(1, sp.shape[1] + 1) * (sr // 2 / sp.shape[1])
+    weights = np.where(
+        freqs > 1350,
+        1.0,
+        np.where(freqs > 550, np.abs((freqs - 550) / (1350 - 550)) ** np.e, 0.0),
+    )
+    return sp * weights[np.newaxis, :]
+
+
+def high_frequency_emphasis(sp: np.ndarray, sr: int) -> np.ndarray:
+    """Emphasize breathiness in the high frequencies."""
+    freqs = np.arange(1, sp.shape[1] + 1) * (sr // 2 / sp.shape[1])
+    weights = np.where(
+        freqs < 1e3,
+        1.0,
+        np.where(freqs < 1e4, (freqs - 1e3) / (1e4 - 1e3) + 1.0, 2.0),
+    )
+    return sp * weights[np.newaxis, :]
+
+
+def convert_noise(f0: np.ndarray) -> np.ndarray:
+    """Replace the excitation signal with white noise."""
+    return np.random.random(f0.shape[0])
+
+
+def covert_pink_noise(f0: np.ndarray) -> np.ndarray:
+    """Generate pink noise using Paul Kellett's IIR approximation."""
+    n = f0.shape[0]
+
+    if not hasattr(covert_pink_noise, "b0"):
+        covert_pink_noise.b0 = 0.0
+        covert_pink_noise.b1 = 0.0
+        covert_pink_noise.b2 = 0.0
+        covert_pink_noise.b3 = 0.0
+        covert_pink_noise.b4 = 0.0
+        covert_pink_noise.b5 = 0.0
+        covert_pink_noise.b6 = 0.0
+
+    b0 = covert_pink_noise.b0
+    b1 = covert_pink_noise.b1
+    b2 = covert_pink_noise.b2
+    b3 = covert_pink_noise.b3
+    b4 = covert_pink_noise.b4
+    b5 = covert_pink_noise.b5
+    b6 = covert_pink_noise.b6
+
+    out = np.zeros(n, dtype=np.float64)
+    for i in range(n):
+        white = np.random.randn()
+        b0 = 0.99886 * b0 + white * 0.0555179
+        b1 = 0.99332 * b1 + white * 0.0750759
+        b2 = 0.96900 * b2 + white * 0.1538520
+        b3 = 0.86650 * b3 + white * 0.3104856
+        b4 = 0.55000 * b4 + white * 0.5329522
+        b5 = -0.7616 * b5 - white * 0.0168980
+        sample = b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362
+        b6 = white * 0.115926
+        out[i] = sample
+
+    covert_pink_noise.b0 = b0
+    covert_pink_noise.b1 = b1
+    covert_pink_noise.b2 = b2
+    covert_pink_noise.b3 = b3
+    covert_pink_noise.b4 = b4
+    covert_pink_noise.b5 = b5
+    covert_pink_noise.b6 = b6
+
+    max_abs = np.max(np.abs(out))
+    if max_abs > 0:
+        out = out / max_abs
+
+    return out
+
+
+def phantom_silhouette(f0: np.ndarray, sp: np.ndarray, sr: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Apply the Phantom Silhouette conversion using white noise."""
+    f0_out = convert_noise(f0)
+    sp_out = sp.copy()
+    sp_out = low_frequency_suppression(sp_out, sr)
+    sp_out = high_frequency_emphasis(sp_out, sr)
+    sp_out[sp_out == 0] = 1e-8
+    return f0_out, sp_out
+
+
+def phantom_silhouette_pink(f0: np.ndarray, sp: np.ndarray, sr: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Apply the Phantom Silhouette conversion using pink noise."""
+    f0_out = covert_pink_noise(f0)
+    sp_out = sp.copy()
+    sp_out = low_frequency_suppression(sp_out, sr)
+    sp_out = high_frequency_emphasis(sp_out, sr)
+    sp_out[sp_out == 0] = 1e-8
+    return f0_out, sp_out
+
+
+def _read_wav(path: str) -> Tuple[np.ndarray, int]:
+    with wave.open(path, "rb") as wf:
+        fs = wf.getframerate()
+        n = wf.getnframes()
+        samples = wf.readframes(n)
+        dtype = {1: np.int8, 2: np.int16, 4: np.int32}[wf.getsampwidth()]
+        x = np.frombuffer(samples, dtype=dtype).astype(np.float64)
+        if wf.getnchannels() > 1:
+            x = x.reshape(-1, wf.getnchannels())[:, 0]
+        if wf.getsampwidth() == 2:
+            x /= 32768.0
+        elif wf.getsampwidth() == 1:
+            x = (x - 128) / 128.0
+        elif wf.getsampwidth() == 4:
+            x /= 2147483648.0
+    return x, fs
+
+
+def _write_wav(path: str, data: np.ndarray, fs: int) -> None:
+    data_i16 = np.clip(data * 32768.0, -32768, 32767).astype(np.int16)
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(fs)
+        wf.writeframes(data_i16.tobytes())
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("Usage: python3 phantom_silhouette.py <input.wav> <output.wav> [pink]", file=sys.stderr)
+        return
+    inp, out = sys.argv[1], sys.argv[2]
+    use_pink = len(sys.argv) > 3 and sys.argv[3] == "pink"
+
+    x, fs = _read_wav(inp)
+    _f0, t = pw.dio(x, fs)
+    f0 = pw.stonemask(x, _f0, t, fs)
+    sp = pw.cheaptrick(x, f0, t, fs)
+    ap = pw.d4c(x, f0, t, fs)
+
+    if use_pink:
+        f0_new, sp_new = phantom_silhouette_pink(f0, sp, fs)
+    else:
+        f0_new, sp_new = phantom_silhouette(f0, sp, fs)
+
+    y = pw.synthesize(f0_new, sp_new, ap, fs)
+    _write_wav(out, y, fs)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/pyproject.toml
+++ b/script/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "world_script"
+version = "0.1.0"
+dependencies = [
+    "numpy",
+    "pyworld",
+    "pedalboard",
+    "soundfile"
+]
+
+[build-system]
+requires = ["uv"]
+build-backend = "uv.build"

--- a/script/test_vst.py
+++ b/script/test_vst.py
@@ -1,0 +1,61 @@
+import os
+import numpy as np
+import soundfile as sf
+from pedalboard import Pedalboard, load_plugin
+import time
+
+VST_PATH = os.path.join(os.path.dirname(__file__), '..', 'target', 'bundled', 'Phantom Silhouette Rs.vst3')
+
+if not os.path.exists(VST_PATH):
+    raise FileNotFoundError(f"VST3 not found at {VST_PATH}. Run 'cargo xtask bundle phantom_silhouette_rs --release' first.")
+
+def resample(audio: np.ndarray, src_sr: int, dst_sr: int) -> np.ndarray:
+    if src_sr == dst_sr:
+        return audio
+    ratio = dst_sr / src_sr
+    num_frames = int(round(audio.shape[1] * ratio))
+    old_pos = np.linspace(0, 1, audio.shape[1], endpoint=False)
+    new_pos = np.linspace(0, 1, num_frames, endpoint=False)
+    return np.stack([np.interp(new_pos, old_pos, ch) for ch in audio])
+
+def process(audio: np.ndarray, sr: int, channels: int) -> tuple[np.ndarray, float]:
+    """Process audio with the VST while internally converting to mono.
+
+    Returns the processed audio and the time taken in seconds.
+    """
+    if audio.ndim == 1:
+        audio = audio[np.newaxis, :]
+    if audio.shape[0] < channels:
+        audio = np.vstack([audio] * channels)[:channels]
+    else:
+        audio = audio[:channels]
+
+    audio = resample(audio, sr, sr)  # ensure correct dtype/resolution (no-op)
+
+    mono = audio.mean(axis=0)
+    stereo_input = np.tile(mono, (2, 1))
+
+    board = Pedalboard([load_plugin(VST_PATH)])
+    start = time.time()
+    stereo_output = board(stereo_input, sr)
+    elapsed = time.time() - start
+    mono_out = stereo_output.mean(axis=0)
+
+    return np.tile(mono_out, (channels, 1)), elapsed
+
+def main():
+    sample_file = os.path.join(os.path.dirname(__file__), '..', 'test_sample', 'a01.wav')
+    audio, fs = sf.read(sample_file)
+    if audio.ndim == 1:
+        audio = audio[np.newaxis, :]
+    else:
+        audio = audio.T
+
+    for sr in (44100, 48000):
+        for ch in (1, 2, 6):
+            data = resample(audio, fs, sr)
+            out, elapsed = process(data, sr, ch)
+            print(f"processed sr={sr} ch={ch} -> {elapsed:.3f}s shape {out.shape}")
+
+if __name__ == '__main__':
+    main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 use nih_plug::prelude::*;
+pub mod noise;
+pub mod phantomsilhouette;
+pub mod spectral;
+pub mod world;
 use std::sync::Arc;
 
 // This is a shortened version of the gain example with most comments removed, check out
@@ -7,22 +11,24 @@ use std::sync::Arc;
 
 struct PhantomSilhouetteRs {
     params: Arc<PhantomSilhouetteRsParams>,
+    sample_rate: f32,
 }
 
 #[derive(Params)]
 struct PhantomSilhouetteRsParams {
-    /// The parameter's ID is used to identify the parameter in the wrappred plugin API. As long as
-    /// these IDs remain constant, you can rename and reorder these fields as you wish. The
-    /// parameters are exposed to the host in the same order they were defined. In this case, this
-    /// gain parameter is stored as linear gain while the values are displayed in decibels.
-    #[id = "gain"]
-    pub gain: FloatParam,
+    /// Cross-fade between the unprocessed input and the whispered "Phantom
+    /// Silhouette" signal. `1.0` keeps only the dry signal while `0.0`
+    /// outputs only the whisper.
+    #[id = "mix"]
+    mix: FloatParam,
+    // Additional parameters were removed in the simplified implementation.
 }
 
 impl Default for PhantomSilhouetteRs {
     fn default() -> Self {
         Self {
             params: Arc::new(PhantomSilhouetteRsParams::default()),
+            sample_rate: 44100.0,
         }
     }
 }
@@ -30,29 +36,9 @@ impl Default for PhantomSilhouetteRs {
 impl Default for PhantomSilhouetteRsParams {
     fn default() -> Self {
         Self {
-            // This gain is stored as linear gain. NIH-plug comes with useful conversion functions
-            // to treat these kinds of parameters as if we were dealing with decibels. Storing this
-            // as decibels is easier to work with, but requires a conversion for every sample.
-            gain: FloatParam::new(
-                "Gain",
-                util::db_to_gain(0.0),
-                FloatRange::Skewed {
-                    min: util::db_to_gain(-30.0),
-                    max: util::db_to_gain(30.0),
-                    // This makes the range appear as if it was linear when displaying the values as
-                    // decibels
-                    factor: FloatRange::gain_skew_factor(-30.0, 30.0),
-                },
-            )
-            // Because the gain parameter is stored as linear gain instead of storing the value as
-            // decibels, we need logarithmic smoothing
-            .with_smoother(SmoothingStyle::Logarithmic(50.0))
-            .with_unit(" dB")
-            // There are many predefined formatters we can use here. If the gain was stored as
-            // decibels instead of as a linear gain value, we could have also used the
-            // `.with_step_size(0.1)` function to get internal rounding.
-            .with_value_to_string(formatters::v2s_f32_gain_to_db(2))
-            .with_string_to_value(formatters::s2v_f32_gain_to_db()),
+            mix: FloatParam::new("Mix", 1.0, FloatRange::Linear { min: 0.0, max: 1.0 })
+                .with_unit("")
+                .with_smoother(SmoothingStyle::Linear(50.0)),
         }
     }
 }
@@ -80,7 +66,6 @@ impl Plugin for PhantomSilhouetteRs {
         names: PortNames::const_default(),
     }];
 
-
     const MIDI_INPUT: MidiConfig = MidiConfig::None;
     const MIDI_OUTPUT: MidiConfig = MidiConfig::None;
 
@@ -102,12 +87,13 @@ impl Plugin for PhantomSilhouetteRs {
     fn initialize(
         &mut self,
         _audio_io_layout: &AudioIOLayout,
-        _buffer_config: &BufferConfig,
+        buffer_config: &BufferConfig,
         _context: &mut impl InitContext<Self>,
     ) -> bool {
         // Resize buffers and perform other potentially expensive initialization operations here.
         // The `reset()` function is always called right after this function. You can remove this
         // function if you do not need it.
+        self.sample_rate = buffer_config.sample_rate;
         true
     }
 
@@ -122,12 +108,22 @@ impl Plugin for PhantomSilhouetteRs {
         _aux: &mut AuxiliaryBuffers,
         _context: &mut impl ProcessContext<Self>,
     ) -> ProcessStatus {
-        for channel_samples in buffer.iter_samples() {
-            // Smoothing is optionally built into the parameters themselves
-            let gain = self.params.gain.smoothed.next();
+        let mix = self.params.mix.smoothed.next();
 
-            for sample in channel_samples {
-                *sample *= gain;
+        let channels = buffer.as_slice();
+        if channels.is_empty() {
+            return ProcessStatus::Normal;
+        }
+
+        let input: Vec<f64> = channels[0].iter().map(|&s| s as f64).collect();
+        let processed = crate::world::phantom_silhouette_signal(&input, self.sample_rate as i32);
+        let processed: Vec<f32> = processed.iter().map(|&v| v as f32).collect();
+
+        for ch in channels.iter_mut() {
+            for (i, sample) in ch.iter_mut().enumerate() {
+                let dry = *sample;
+                let phantom = processed[i];
+                *sample = mix * dry + (1.0 - mix) * phantom;
             }
         }
 

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,0 +1,105 @@
+use rand::distributions::Standard;
+use rand::{thread_rng, Rng};
+use rand_distr::{Distribution, StandardNormal};
+
+/// Streaming pink noise generator based on Paul Kellett's IIR approximation.
+#[derive(Debug, Clone)]
+pub struct PinkNoiseGen {
+    b: [f64; 7],
+}
+
+impl PinkNoiseGen {
+    pub fn new() -> Self {
+        Self { b: [0.0; 7] }
+    }
+
+    /// Generate a single pink noise sample in the range [-1.0, 1.0].
+    pub fn next(&mut self, rng: &mut impl Rng) -> f64 {
+        let white: f64 = rng.sample(StandardNormal);
+        self.b[0] = 0.99886 * self.b[0] + white * 0.0555179;
+        self.b[1] = 0.99332 * self.b[1] + white * 0.0750759;
+        self.b[2] = 0.96900 * self.b[2] + white * 0.1538520;
+        self.b[3] = 0.86650 * self.b[3] + white * 0.3104856;
+        self.b[4] = 0.55000 * self.b[4] + white * 0.5329522;
+        self.b[5] = -0.7616 * self.b[5] - white * 0.0168980;
+        let sample = self.b[0]
+            + self.b[1]
+            + self.b[2]
+            + self.b[3]
+            + self.b[4]
+            + self.b[5]
+            + self.b[6]
+            + white * 0.5362;
+        self.b[6] = white * 0.115926;
+
+        sample
+    }
+}
+
+/// Generate uniform white noise of length `n`.
+pub fn white_noise(n: usize) -> Vec<f64> {
+    let mut rng = thread_rng();
+    (0..n).map(|_| rng.sample(Standard)).collect()
+}
+
+/// Generate pink noise using Paul Kellett's IIR approximation.
+/// The internal filter state is preserved across calls.
+pub fn pink_noise(n: usize) -> Vec<f64> {
+    static mut STATE: [f64; 7] = [0.0; 7];
+    let mut rng = thread_rng();
+    let mut out = vec![0.0; n];
+
+    for i in 0..n {
+        let white: f64 = StandardNormal.sample(&mut rng);
+        unsafe {
+            STATE[0] = 0.99886 * STATE[0] + white * 0.0555179;
+            STATE[1] = 0.99332 * STATE[1] + white * 0.0750759;
+            STATE[2] = 0.96900 * STATE[2] + white * 0.1538520;
+            STATE[3] = 0.86650 * STATE[3] + white * 0.3104856;
+            STATE[4] = 0.55000 * STATE[4] + white * 0.5329522;
+            STATE[5] = -0.7616 * STATE[5] - white * 0.0168980;
+            let sample = STATE[0]
+                + STATE[1]
+                + STATE[2]
+                + STATE[3]
+                + STATE[4]
+                + STATE[5]
+                + STATE[6]
+                + white * 0.5362;
+            STATE[6] = white * 0.115926;
+            out[i] = sample;
+        }
+    }
+
+    let max = out.iter().fold(0.0_f64, |a, &b| a.max(b.abs()));
+    if max > 0.0 {
+        for v in &mut out {
+            *v /= max;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_white_noise_range() {
+        let n = 1000;
+        let noise = white_noise(n);
+        assert_eq!(noise.len(), n);
+        for &v in &noise {
+            assert!(v >= 0.0 && v <= 1.0);
+        }
+    }
+
+    #[test]
+    fn test_pink_noise_range() {
+        let n = 1024;
+        let noise = pink_noise(n);
+        let max = noise.iter().cloned().fold(f64::MIN, f64::max);
+        let min = noise.iter().cloned().fold(f64::MAX, f64::min);
+        assert!(max <= 1.0 && min >= -1.0);
+    }
+}

--- a/src/phantomsilhouette.rs
+++ b/src/phantomsilhouette.rs
@@ -1,0 +1,40 @@
+use crate::noise::{pink_noise, white_noise};
+use crate::spectral::{high_frequency_emphasis, low_frequency_suppression};
+
+/// Apply the Phantom Silhouette conversion using white noise.
+/// Returns the new excitation and modified spectral envelope.
+pub fn phantom_silhouette(f0: &[f64], sp: &[Vec<f64>], sr: usize) -> (Vec<f64>, Vec<Vec<f64>>) {
+    let f0_out = white_noise(f0.len());
+    let mut sp_out = sp.to_vec();
+    sp_out = low_frequency_suppression(sp_out, sr);
+    sp_out = high_frequency_emphasis(sp_out, sr);
+    (f0_out, sp_out)
+}
+
+/// Apply the Phantom Silhouette conversion using pink noise.
+pub fn phantom_silhouette_pink(
+    f0: &[f64],
+    sp: &[Vec<f64>],
+    sr: usize,
+) -> (Vec<f64>, Vec<Vec<f64>>) {
+    let f0_out = pink_noise(f0.len());
+    let mut sp_out = sp.to_vec();
+    sp_out = low_frequency_suppression(sp_out, sr);
+    sp_out = high_frequency_emphasis(sp_out, sr);
+    (f0_out, sp_out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_phantom_silhouette_shapes() {
+        let f0 = vec![0.0; 256];
+        let sp = vec![vec![1.0; 128]; 256];
+        let (f0_out, sp_out) = phantom_silhouette(&f0, &sp, 48000);
+        assert_eq!(f0_out.len(), f0.len());
+        assert_eq!(sp_out.len(), sp.len());
+        assert_eq!(sp_out[0].len(), sp[0].len());
+    }
+}

--- a/src/spectral.rs
+++ b/src/spectral.rs
@@ -1,0 +1,58 @@
+/// Spectral processing helpers used by the Phantom Silhouette algorithm.
+
+/// Suppress low frequency components.
+pub fn low_frequency_suppression(mut sp: Vec<Vec<f64>>, sr: usize) -> Vec<Vec<f64>> {
+    let len = sp.get(0).map_or(0, |row| row.len());
+    let step = sr as f64 / 2.0 / len as f64;
+    for row in &mut sp {
+        for (i, val) in row.iter_mut().enumerate() {
+            let f = (i + 1) as f64 * step;
+            let w = if f > 1350.0 {
+                1.0
+            } else if f > 550.0 {
+                ((f - 550.0) / (1350.0 - 550.0))
+                    .abs()
+                    .powf(std::f64::consts::E)
+            } else {
+                0.0
+            };
+            *val *= w;
+        }
+    }
+    sp
+}
+
+/// Emphasize high frequency breathiness.
+pub fn high_frequency_emphasis(mut sp: Vec<Vec<f64>>, sr: usize) -> Vec<Vec<f64>> {
+    let len = sp.get(0).map_or(0, |row| row.len());
+    let step = sr as f64 / 2.0 / len as f64;
+    for row in &mut sp {
+        for (i, val) in row.iter_mut().enumerate() {
+            let f = (i + 1) as f64 * step;
+            let w = if f < 1000.0 {
+                1.0
+            } else if f < 10000.0 {
+                (f - 1000.0) / (10000.0 - 1000.0) + 1.0
+            } else {
+                2.0
+            };
+            *val *= w;
+        }
+    }
+    sp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_spectral_shape() {
+        let sp = vec![vec![1.0; 16]; 4];
+        let sup = low_frequency_suppression(sp.clone(), 48000);
+        assert_eq!(sup.len(), sp.len());
+        assert_eq!(sup[0].len(), sp[0].len());
+        let emp = high_frequency_emphasis(sp.clone(), 48000);
+        assert_eq!(emp[0].len(), sp[0].len());
+    }
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,0 +1,30 @@
+use Rust_WORLD::rsworld::{cheaptrick, d4c, dio, stonemask, synthesis};
+use Rust_WORLD::rsworld_sys::{CheapTrickOption, D4COption, DioOption};
+use crate::phantomsilhouette::phantom_silhouette_pink;
+
+pub fn extract_f0(x: &[f64], fs: i32) -> Vec<f64> {
+    let option = DioOption::new();
+    let (time_axis, f0) = dio(&x.to_vec(), fs, &option);
+    let refined = stonemask(&x.to_vec(), fs, &time_axis, &f0);
+    refined
+}
+
+/// Apply the Phantom Silhouette conversion with pink noise using WORLD.
+pub fn phantom_silhouette_signal(x: &[f64], fs: i32) -> Vec<f64> {
+    let dio_opt = DioOption::new();
+    let (time, f0) = dio(&x.to_vec(), fs, &dio_opt);
+    let f0 = stonemask(&x.to_vec(), fs, &time, &f0);
+
+    let mut ct_opt = CheapTrickOption::new(fs);
+    let sp = cheaptrick(&x.to_vec(), fs, &time, &f0, &mut ct_opt);
+    let d4c_opt = D4COption::new();
+    let ap = d4c(&x.to_vec(), fs, &time, &f0, &d4c_opt);
+
+    let (f0_new, sp_new) = phantom_silhouette_pink(&f0, &sp, fs as usize);
+
+    let mut y = synthesis(&f0_new, &sp_new, &ap, dio_opt.frame_period, fs);
+    if y.len() > x.len() {
+        y.truncate(x.len());
+    }
+    y
+}

--- a/tests/world_integration.rs
+++ b/tests/world_integration.rs
@@ -1,0 +1,59 @@
+use phantom_silhouette_rs::world::extract_f0;
+use std::process::Command;
+
+fn read_wav(path: &str) -> (Vec<f64>, i32) {
+    let mut reader = hound::WavReader::open(path).unwrap();
+    let spec = reader.spec();
+    let fs = spec.sample_rate as i32;
+    let samples: Vec<f64> = reader
+        .samples::<i16>()
+        .map(|s| s.unwrap() as f64 / 32768.0)
+        .collect();
+    (samples, fs)
+}
+
+#[test]
+fn compare_f0_with_python() {
+    let path = "test_sample/a01.wav";
+    let (samples, fs) = read_wav(path);
+    let rust_f0 = extract_f0(&samples, fs);
+
+    // Ensure the Python dependencies are available. If not, skip the test.
+    let check = Command::new("python3")
+        .arg("-c")
+        .arg("import numpy, pyworld")
+        .output()
+        .expect("run python");
+    if !check.status.success() {
+        eprintln!("skipping python comparison – missing dependencies");
+        return;
+    }
+
+    let output = Command::new("python3")
+        .arg("script/extract_f0.py")
+        .arg(path)
+        .output()
+        .expect("run python");
+    assert!(
+        output.status.success(),
+        "python failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let py_f0: Vec<f64> = stdout
+        .split_whitespace()
+        .filter_map(|s| s.parse::<f64>().ok())
+        .collect();
+
+    assert_eq!(rust_f0.len(), py_f0.len());
+
+    let mut voiced_diffs = Vec::new();
+    for (&a, &b) in rust_f0.iter().zip(py_f0.iter()) {
+        if a != 0.0 || b != 0.0 {
+            voiced_diffs.push((a - b).abs());
+        }
+    }
+
+    let diff: f64 = voiced_diffs.iter().copied().sum::<f64>() / voiced_diffs.len() as f64;
+    assert!(diff < 1e-6, "diff {} too high", diff);
+}


### PR DESCRIPTION
## Summary
- use WORLD vocoder to analyze and resynthesize audio
- add function `phantom_silhouette_signal` for the conversion
- update plugin to run full Phantom Silhouette processing
- describe updated behaviour in the README
- fix unused mutable variable
- measure runtime of the VST processing script

## Testing
- `cargo test --quiet`
- `cargo test --test world_integration -- --nocapture`
- `cargo xtask bundle phantom_silhouette_rs --release`
- `python3 script/test_vst.py`


------
https://chatgpt.com/codex/tasks/task_e_68569a99419883279f2cea91342b28cb